### PR TITLE
hooks for accessing context values

### DIFF
--- a/packages/ReactDagEditor/src/components/AlignmentLines.tsx
+++ b/packages/ReactDagEditor/src/components/AlignmentLines.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { AlignmentLinesContext } from "../contexts/AlignmentLinesContext";
+import { useAlignmentLines } from "../hooks/context";
 import { Line } from "./Line";
 
 interface IProps {
@@ -7,7 +7,7 @@ interface IProps {
 }
 
 const AlignmentLines = React.memo<IProps>(({ style }) => {
-  const alignmentLines = React.useContext(AlignmentLinesContext);
+  const alignmentLines = useAlignmentLines();
   return (
     <>
       {alignmentLines.map((l, index) => {

--- a/packages/ReactDagEditor/src/components/AnimatingNodeGroup.tsx
+++ b/packages/ReactDagEditor/src/components/AnimatingNodeGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
 import { useTheme } from "../hooks";
+import { useGraphConfig } from "../hooks/context";
 import { IDummyNodes } from "../models/dummy-node";
 import { GraphModel } from "../models/GraphModel";
 import { getNodeConfig } from "../utils";
@@ -12,7 +12,7 @@ interface IAnimatingNodeGroup {
 
 export const AnimatingNodeGroup: React.FunctionComponent<IAnimatingNodeGroup> = props => {
   const { dummyNodes, graphData } = props;
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const { theme } = useTheme();
   const { dWidth, dHeight } = dummyNodes;
   const dx = dummyNodes.alignedDX ?? dummyNodes.dx;

--- a/packages/ReactDagEditor/src/components/Connecting/Connecting.tsx
+++ b/packages/ReactDagEditor/src/components/Connecting/Connecting.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IGraphConfig } from "../../contexts";
-import { ConnectingStateContext } from "../../contexts/ConnectingStateContext";
+import { useConnectingState } from "../../hooks/context";
 import { IPoint, IViewport } from "../../models/geometry";
 import { transformPoint } from "../../utils";
 import { EventChannel } from "../../utils/eventChannel";
@@ -17,7 +17,7 @@ interface IConnectingProps {
 
 export const Connecting = React.memo<IConnectingProps>(props => {
   const { styles, graphConfig, viewport, movingPoint } = props;
-  const { sourcePort, sourceNode, targetPort, targetNode } = React.useContext(ConnectingStateContext);
+  const { sourcePort, sourceNode, targetPort, targetNode } = useConnectingState();
   if (!sourceNode || !sourcePort) {
     return null;
   }

--- a/packages/ReactDagEditor/src/components/Graph/Graph.tsx
+++ b/packages/ReactDagEditor/src/components/Graph/Graph.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines */
 import * as React from "react";
 import { v4 as uuid } from "uuid";
-import { GraphConfigContext, IGraphConfig } from "../../contexts";
-import { GraphControllerContext } from "../../contexts/GraphControllerContext";
 import {
   useContainerRect,
   useGraphState,
@@ -16,6 +14,7 @@ import {
 import { useConst } from "../../hooks/useConst";
 import { useEventChannel } from "../../hooks/useEventChannel";
 import { useFeatureControl } from "../../hooks/useFeatureControl";
+import { useGraphConfig, useGraphController } from "../../hooks/context";
 import { GraphCanvasEvent, GraphContextMenuEvent, ICanvasCommonEvent, ICanvasKeyboardEvent } from "../../models/event";
 import { IContainerRect, IViewport } from "../../models/geometry";
 import { GraphBehavior } from "../../models/state";
@@ -44,7 +43,7 @@ export function Graph<NodeData = unknown, EdgeData = unknown, PortData = unknown
 ): React.ReactElement | null {
   const [focusedWithoutMouse, setFocusedWithoutMouse] = React.useState<boolean>(false);
 
-  const graphController = React.useContext(GraphControllerContext);
+  const graphController = useGraphController();
   const { state, dispatch } = useGraphState();
   const data = state.data.present;
   const { viewport } = state;
@@ -67,7 +66,7 @@ export function Graph<NodeData = unknown, EdgeData = unknown, PortData = unknown
   } = props;
 
   const { theme } = useTheme();
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const featureControl = useFeatureControl(state.settings.features);
 
   graphConfig.defaultNodeShape = defaultNodeShape;
@@ -263,13 +262,7 @@ export function Graph<NodeData = unknown, EdgeData = unknown, PortData = unknown
               eventChannel={eventChannel}
             >
               <GraphGroupsRenderer data={data} groups={data.groups ?? constantEmptyArray()} />
-              <EdgeTree
-                graphId={graphId}
-                tree={data.edges}
-                data={data}
-                graphConfig={graphConfig}
-                eventChannel={eventChannel}
-              />
+              <EdgeTree graphId={graphId} tree={data.edges} data={data} eventChannel={eventChannel} />
               <NodeTree
                 graphId={graphId}
                 isNodeResizable={isNodeResizable}

--- a/packages/ReactDagEditor/src/components/Graph/GraphStateStore.tsx
+++ b/packages/ReactDagEditor/src/components/Graph/GraphStateStore.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { ConnectingState } from "../../ConnectingState";
-import { EMPTY_GAP, EMPTY_TRANSFORM_MATRIX, GraphConfigContext, IGraphReducer, ViewportContext } from "../../contexts";
+import { EMPTY_GAP, EMPTY_TRANSFORM_MATRIX, IGraphReducer, ViewportContext } from "../../contexts";
 import { AlignmentLinesContext } from "../../contexts/AlignmentLinesContext";
 import { GraphControllerContext } from "../../contexts/GraphControllerContext";
 import { GraphStateContext, GraphValueContext } from "../../contexts/GraphStateContext";
 import { GraphController } from "../../controllers/GraphController";
 import { defaultFeatures, GraphFeatures } from "../../Features";
 import { useConst } from "../../hooks/useConst";
+import { useGraphConfig } from "../../hooks/context";
 import { useGraphReducer } from "../../hooks/useGraphReducer";
 import { IGap, ITransformMatrix } from "../../models/geometry";
 import { GraphModel } from "../../models/GraphModel";
@@ -32,7 +33,7 @@ export function GraphStateStore<NodeData = unknown, EdgeData = unknown, PortData
     canvasBoundaryPadding = EMPTY_GAP
   } = props;
 
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   const [state, dispatch] = useGraphReducer(
     {

--- a/packages/ReactDagEditor/src/components/GraphEdge.tsx
+++ b/packages/ReactDagEditor/src/components/GraphEdge.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
-import { VirtualizationContext } from "../contexts/VirtualizationContext";
+import { useGraphConfig, useVirtualization } from "../hooks/context";
 import { GraphEdgeEvent, IEdgeCommonEvent } from "../models/event";
 import { IPoint, IRectShape } from "../models/geometry";
 import { GraphEdgeState } from "../models/element-state";
@@ -13,7 +12,6 @@ import { EventChannel } from "../utils/eventChannel";
 
 export interface IGraphEdgeCommonProps {
   data: GraphModel;
-  graphConfig: IGraphConfig;
   eventChannel: EventChannel;
   graphId: string;
 }
@@ -56,9 +54,9 @@ export const GraphEdge: React.FunctionComponent<IGraphEdgeProps> = React.memo(
   // eslint-disable-next-line complexity
   props => {
     const { edge, data: graphModel, eventChannel, source, target, graphId } = props;
-    const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+    const graphConfig = useGraphConfig();
 
-    const virtualization = React.useContext(VirtualizationContext);
+    const virtualization = useVirtualization();
     const { viewport, renderedArea, visibleArea } = virtualization;
 
     const { theme } = useTheme();

--- a/packages/ReactDagEditor/src/components/GraphNode.tsx
+++ b/packages/ReactDagEditor/src/components/GraphNode.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
 import { useTheme } from "../hooks";
+import { useGraphConfig } from "../hooks/context";
 import { GraphNodeEvent, INodeCommonEvent, INodeContextMenuEvent } from "../models/event";
 import { IViewport } from "../models/geometry";
 import { NodeModel } from "../models/NodeModel";
@@ -26,7 +26,7 @@ export interface IGraphNodeProps extends IGraphNodeCommonProps {
 
 const GraphNode: React.FunctionComponent<IGraphNodeProps> = props => {
   const { node, eventChannel, getNodeAriaLabel, viewport, graphId } = props;
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const shape = node.shape ? node.shape : graphConfig.defaultNodeShape;
   const nodeConfig = getNodeConfig(node, graphConfig);
   const { theme } = useTheme();

--- a/packages/ReactDagEditor/src/components/GraphNodeControlPoints.tsx
+++ b/packages/ReactDagEditor/src/components/GraphNodeControlPoints.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig, ITheme } from "../contexts";
-import { GraphControllerContext } from "../contexts/GraphControllerContext";
+import { ITheme } from "../contexts";
 import { defaultGetPositionFromEvent, DragController } from "../controllers";
 import { MouseMoveEventProvider } from "../event-provider/MouseMoveEventProvider";
 import { useTheme } from "../hooks";
+import { useGraphConfig, useGraphController } from "../hooks/context";
 import { GraphNodeEvent } from "../models/event";
 import { INodeGeometryDelta } from "../models/GraphModel";
 import { NodeModel } from "../models/NodeModel";
@@ -45,9 +45,9 @@ const ResizePoint: React.FunctionComponent<IResizePointProps> = ({ x, y, cursor,
 export const GraphNodeControlPoints: React.FunctionComponent<IGraphNodeControlPointsProps> = props => {
   const { node, eventChannel } = props;
 
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const nodeConfig = getNodeConfig(node, graphConfig);
-  const graphController = React.useContext(GraphControllerContext);
+  const graphController = useGraphController();
 
   const minWidth = nodeConfig.getMinWidth(node);
   const minHeight = nodeConfig.getMinHeight(node);

--- a/packages/ReactDagEditor/src/components/GraphNodeParts.tsx
+++ b/packages/ReactDagEditor/src/components/GraphNodeParts.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { VirtualizationContext } from "../contexts/VirtualizationContext";
+import { useVirtualization } from "../hooks/context";
 import { NodeModel } from "../models/NodeModel";
 import { isNodeEditing, isPointInRect } from "../utils";
 import { GraphNode, IGraphNodeCommonProps } from "./GraphNode";
@@ -14,7 +14,7 @@ export interface IGraphNodePartsProps
 }
 
 const GraphNodeParts = ({ node, isNodeResizable, ...commonProps }: IGraphNodePartsProps) => {
-  const virtualization = React.useContext(VirtualizationContext);
+  const virtualization = useVirtualization();
   const { renderedArea, viewport } = virtualization;
 
   const isVisible = isPointInRect(renderedArea, node);

--- a/packages/ReactDagEditor/src/components/GraphOneNodePorts.tsx
+++ b/packages/ReactDagEditor/src/components/GraphOneNodePorts.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
 import { ConnectingStateContext } from "../contexts/ConnectingStateContext";
 import { useTheme } from "../hooks";
+import { useGraphConfig } from "../hooks/context";
 import { GraphPortEvent } from "../models/event";
 import { GraphModel } from "../models/GraphModel";
 import { NodeModel } from "../models/NodeModel";
@@ -20,7 +20,7 @@ export interface IGraphOneNodePortsProps
 
 export const GraphOneNodePorts: React.FunctionComponent<IGraphOneNodePortsProps> = props => {
   const { data, node, getPortAriaLabel, eventChannel, viewport, graphId } = props;
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const { theme } = useTheme();
 
   const ports = node.ports;

--- a/packages/ReactDagEditor/src/components/Group/Group.tsx
+++ b/packages/ReactDagEditor/src/components/Group/Group.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { defaultGroup } from "../../built-in/defaultGroup";
-import {
-  GraphConfigContext,
-  IGraphConfig
-} from "../../contexts/GraphConfigContext";
+import { useGraphConfig } from "../../hooks/context";
 import { ICanvasGroup } from "../../models/canvas";
 import { GraphModel } from "../../models/GraphModel";
 import { getGroupRect } from "../../utils/layout";
@@ -15,14 +12,14 @@ export interface IGroupProps {
 
 export const Group: React.FC<IGroupProps> = props => {
   const { data, group } = props;
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
-  const { x, y, width, height } = React.useMemo(
-    () => getGroupRect(group, data.nodes, graphConfig),
-    [group, data.nodes, graphConfig]
-  );
+  const graphConfig = useGraphConfig();
+  const { x, y, width, height } = React.useMemo(() => getGroupRect(group, data.nodes, graphConfig), [
+    group,
+    data.nodes,
+    graphConfig
+  ]);
 
-  const groupConfig =
-    graphConfig.getGroupConfigByName(group.shape) ?? defaultGroup;
+  const groupConfig = graphConfig.getGroupConfigByName(group.shape) ?? defaultGroup;
 
   const automationId = `group-container-${group.id}`;
   return (

--- a/packages/ReactDagEditor/src/components/ItemPanel/AddingNodeSvg.tsx
+++ b/packages/ReactDagEditor/src/components/ItemPanel/AddingNodeSvg.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { v4 as uuid } from "uuid";
-import { GraphConfigContext, ViewportContext } from "../../contexts";
-import { AlignmentLinesContext } from "../../contexts/AlignmentLinesContext";
-import { GraphControllerContext } from "../../contexts/GraphControllerContext";
 import { useConst } from "../../hooks/useConst";
+import { useAlignmentLines, useGraphConfig, useGraphController, useViewport } from "../../hooks/context";
 import { GraphCanvasEvent } from "../../models/event";
 import { ICanvasNode } from "../../models/node";
 import { NodeModel } from "../../models/NodeModel";
@@ -28,10 +26,10 @@ export const AddingNodeSvg: React.FunctionComponent<IAddingNodeSvgProps<unknown,
   nextNodeRef
 }) => {
   const rect = useSvgRect(svgRef);
-  const graphConfig = React.useContext(GraphConfigContext);
-  const graphController = React.useContext(GraphControllerContext);
-  const alignmentLines = React.useContext(AlignmentLinesContext);
-  const viewport = React.useContext(ViewportContext);
+  const graphConfig = useGraphConfig();
+  const graphController = useGraphController();
+  const alignmentLines = useAlignmentLines();
+  const viewport = useViewport();
 
   const dummyNode = React.useMemo(() => {
     if (!model || !viewport.rect) {

--- a/packages/ReactDagEditor/src/components/ItemPanel/Item.tsx
+++ b/packages/ReactDagEditor/src/components/ItemPanel/Item.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { v4 as uuid } from "uuid";
 import { MouseEventButton } from "../../common/constants";
-import { emptyNodeConfig, GraphConfigContext, IRectConfig } from "../../contexts";
-import { GraphControllerContext } from "../../contexts/GraphControllerContext";
+import { emptyNodeConfig, IRectConfig } from "../../contexts";
 import { defaultGetPositionFromEvent, DragController } from "../../controllers";
 import { PointerEventProvider } from "../../event-provider/PointerEventProvider";
 import { GraphFeatures } from "../../Features";
+import { useGraphConfig, useGraphController } from "../../hooks/context";
 import { useRefValue } from "../../hooks/useRefValue";
 import { GraphCanvasEvent } from "../../models/event";
 import { IContainerRect, IPoint, ITransformMatrix } from "../../models/geometry";
@@ -108,8 +108,8 @@ const adjustPosition = <T extends { width?: number; height?: number }>(
  * @returns
  */
 export const Item: React.FunctionComponent<IItemProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
-  const graphController = React.useContext(GraphControllerContext);
+  const graphConfig = useGraphConfig();
+  const graphController = useGraphController();
   const [workingModel, setWorkingModel] = React.useState<ICanvasNode | null>(null);
   const nextNodeRef = useRefValue(workingModel);
   const svgRef = React.useRef<SVGSVGElement>(null);

--- a/packages/ReactDagEditor/src/components/Minimap/Minimap.tsx
+++ b/packages/ReactDagEditor/src/components/Minimap/Minimap.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
-import { EMPTY_TRANSFORM_MATRIX, GraphConfigContext, IGraphConfig, ViewportContext } from "../../contexts";
-import { GraphControllerContext } from "../../contexts/GraphControllerContext";
-import { GraphStateContext } from "../../contexts/GraphStateContext";
+import { EMPTY_TRANSFORM_MATRIX } from "../../contexts";
 import { DragController, ITouchHandler, TouchController } from "../../controllers";
 import { TouchDragAdapter } from "../../controllers/TouchDragAdapter";
 import { MouseMoveEventProvider } from "../../event-provider/MouseMoveEventProvider";
 import { IEventProvider, IGlobalMoveEventTypes } from "../../event-provider/types";
-import { useMinimapRect, useTheme } from "../../hooks";
+import { useGraphData, useMinimapRect, useTheme } from "../../hooks";
+import { useGraphConfig, useGraphController, useViewport } from "../../hooks/context";
 import { useRefValue } from "../../hooks/useRefValue";
 import { GraphCanvasEvent, GraphMinimapEvent } from "../../models/event";
 import { ITransformMatrix } from "../../models/geometry";
@@ -62,18 +61,17 @@ export const Minimap: React.FunctionComponent<IMiniMapProps> = props => {
     renderArrow = (arrowDeg: number) => undefined
   } = props;
 
-  const graphViewport = React.useContext(ViewportContext);
-  const graphController = React.useContext(GraphControllerContext);
+  const graphViewport = useViewport();
+  const graphController = useGraphController();
   const { theme } = useTheme();
-  const { data: dataState } = React.useContext(GraphStateContext).state;
-  const data = dataState.present;
+  const data = useGraphData();
   const minimapContainerStyle: React.CSSProperties = {
     background: theme.minimapBackground,
     ...props.style
   };
 
   const svgRef = React.useRef<SVGSVGElement>(null);
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   const rect = useMinimapRect(svgRef);
   const rectRef = useRefValue(rect);

--- a/packages/ReactDagEditor/src/components/NodeTooltips.tsx
+++ b/packages/ReactDagEditor/src/components/NodeTooltips.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
+import { useGraphConfig } from "../hooks/context";
 import { GraphNodeState } from "../models/element-state";
 import { useTheme } from "../hooks";
 import { IViewport } from "../models/geometry";
@@ -13,7 +13,7 @@ interface IProps {
 
 export const NodeTooltips: React.FunctionComponent<IProps> = props => {
   const { node, viewport } = props;
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const { theme } = useTheme();
 
   if (!node) {

--- a/packages/ReactDagEditor/src/components/PortTooltips.tsx
+++ b/packages/ReactDagEditor/src/components/PortTooltips.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../contexts";
 import { ConnectingStateContext } from "../contexts/ConnectingStateContext";
+import { useGraphConfig } from "../hooks/context";
 import { IViewport } from "../models/geometry";
 import { ICanvasPort } from "../models/port";
 import { GraphPortState } from "../models/element-state";
@@ -17,7 +17,7 @@ interface IPortTooltipsProps {
 }
 
 export const PortTooltips: React.FunctionComponent<IPortTooltipsProps> = props => {
-  const graphConfig = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const { theme } = useTheme();
 
   const { parentNode, port, viewport } = props;

--- a/packages/ReactDagEditor/src/components/RegisterComponent/RegisterClipboard.tsx
+++ b/packages/ReactDagEditor/src/components/RegisterComponent/RegisterClipboard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IGraphClipBoard } from "../../built-in/defaultClipboard";
-import { GraphConfigContext } from "../../contexts";
+import { useGraphConfig } from "../../hooks/context";
 
 export interface IRegisterClipboardProps {
   /**
@@ -16,7 +16,7 @@ export interface IRegisterClipboardProps {
  * @param props
  */
 export const RegisterClipboard: React.FunctionComponent<IRegisterClipboardProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   React.useEffect(() => {
     graphConfig.registerClipboard(props.clipboard);

--- a/packages/ReactDagEditor/src/components/RegisterComponent/RegisterEdge.tsx
+++ b/packages/ReactDagEditor/src/components/RegisterComponent/RegisterEdge.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IEdgeConfig } from "../../contexts";
+import { IEdgeConfig } from "../../contexts";
+import { useGraphConfig } from "../../hooks/context";
 
 export interface IRegisterEdgeProps {
   /**
@@ -19,7 +20,7 @@ export interface IRegisterEdgeProps {
  * @param props
  */
 export const RegisterEdge: React.FunctionComponent<IRegisterEdgeProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   graphConfig.registerEdge(props.name, props.config);
 

--- a/packages/ReactDagEditor/src/components/RegisterComponent/RegisterGroup.tsx
+++ b/packages/ReactDagEditor/src/components/RegisterComponent/RegisterGroup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IGroupConfig } from "../../contexts";
+import { IGroupConfig } from "../../contexts";
+import { useGraphConfig } from "../../hooks/context";
 
 export interface IRegisterGroupProps {
   /**
@@ -19,7 +20,7 @@ export interface IRegisterGroupProps {
  * @param props
  */
 export const RegisterGroup: React.FunctionComponent<IRegisterGroupProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   graphConfig.registerGroup(props.name, props.config);
 

--- a/packages/ReactDagEditor/src/components/RegisterComponent/RegisterNode.tsx
+++ b/packages/ReactDagEditor/src/components/RegisterComponent/RegisterNode.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IRectConfig } from "../../contexts";
+import { IRectConfig } from "../../contexts";
+import { useGraphConfig } from "../../hooks/context";
 import { ICanvasNode } from "../../models/node";
 
 export interface IRegisterNodeProps {
@@ -20,7 +21,7 @@ export interface IRegisterNodeProps {
  * @param props
  */
 export const RegisterNode: React.FunctionComponent<IRegisterNodeProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   graphConfig.registerNode(props.name, props.config);
 

--- a/packages/ReactDagEditor/src/components/RegisterComponent/RegisterPort.tsx
+++ b/packages/ReactDagEditor/src/components/RegisterComponent/RegisterPort.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IPortConfig } from "../../contexts";
+import { IPortConfig } from "../../contexts";
+import { useGraphConfig } from "../../hooks/context";
 
 export interface IRegisterPortProps {
   /**
@@ -19,7 +20,7 @@ export interface IRegisterPortProps {
  * @param props
  */
 export const RegisterPort: React.FunctionComponent<IRegisterPortProps> = props => {
-  const graphConfig = React.useContext(GraphConfigContext);
+  const graphConfig = useGraphConfig();
 
   graphConfig.registerPort(props.name, props.config);
 

--- a/packages/ReactDagEditor/src/components/Scrollbar.tsx
+++ b/packages/ReactDagEditor/src/components/Scrollbar.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { createUseStyles } from "react-jss";
-import { GraphControllerContext } from "../contexts/GraphControllerContext";
 import { IDispatch } from "../contexts/GraphStateContext";
 import { ITheme } from "../contexts/ThemeContext";
 import { defaultGetPositionFromEvent, DragController } from "../controllers/DragController";
 import { MouseMoveEventProvider } from "../event-provider/MouseMoveEventProvider";
+import { useGraphController } from "../hooks/context";
 import { useRefValue } from "../hooks/useRefValue";
 import { useTheme } from "../hooks/useTheme";
 import { GraphScrollBarEvent } from "../models/event";
@@ -75,7 +75,7 @@ const useStyles = createUseStyles({
 export const Scrollbar: React.FC<IProps> = props => {
   const { vertical = true, horizontal = true, offsetLimit, eventChannel, viewport } = props;
 
-  const graphController = React.useContext(GraphControllerContext);
+  const graphController = useGraphController();
   const { theme } = useTheme();
 
   const scrollbarLayout = getScrollbarLayout(viewport, offsetLimit);

--- a/packages/ReactDagEditor/src/components/StaticGraph/StaticNode.tsx
+++ b/packages/ReactDagEditor/src/components/StaticGraph/StaticNode.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { GraphConfigContext, IGraphConfig } from "../../contexts";
 import { useTheme } from "../../hooks";
+import { useGraphConfig } from "../../hooks/context";
 import { ICanvasNode } from "../../models/node";
 import { getNodeConfig, getRectHeight, getRectWidth } from "../../utils";
 
@@ -10,10 +10,10 @@ interface IStaticNodeProps {
 
 const StaticNode: React.FunctionComponent<IStaticNodeProps> = props => {
   const { node } = props;
-  const graphConfigContext = React.useContext<IGraphConfig>(GraphConfigContext);
+  const graphConfig = useGraphConfig();
   const { theme } = useTheme();
 
-  const nodeConfig = getNodeConfig(node, graphConfigContext);
+  const nodeConfig = getNodeConfig(node, graphConfig);
 
   if (nodeConfig.renderStatic) {
     return <g>{nodeConfig.renderStatic({ model: node, theme })}</g>;

--- a/packages/ReactDagEditor/src/components/tree/EdgeTree.tsx
+++ b/packages/ReactDagEditor/src/components/tree/EdgeTree.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { HashMap } from "../../collections";
 import { BitmapIndexedNode, HashCollisionNode, NodeType } from "../../collections/champ";
+import { useGraphConfig } from "../../hooks/context";
 import { EdgeModel } from "../../models/EdgeModel";
 import { GraphEdge, IGraphEdgeCommonProps } from "../GraphEdge";
 
@@ -24,7 +25,8 @@ function compareEqual(
 }
 
 const EdgeChampNodeRender = React.memo<IEdgeChampNodeRenderProps>(props => {
-  const { node, data, graphConfig, ...others } = props;
+  const { node, data, ...others } = props;
+  const graphConfig = useGraphConfig();
   const values: React.ReactNode[] = [];
   const valueCount = node.valueCount;
   for (let i = 0; i < valueCount; i += 1) {
@@ -32,17 +34,7 @@ const EdgeChampNodeRender = React.memo<IEdgeChampNodeRenderProps>(props => {
     const source = data.nodes.get(it.source)?.getPortPosition(it.sourcePortId, graphConfig);
     const target = data.nodes.get(it.target)?.getPortPosition(it.targetPortId, graphConfig);
     if (source && target) {
-      values.push(
-        <GraphEdge
-          {...others}
-          key={it.id}
-          data={data}
-          graphConfig={graphConfig}
-          edge={it}
-          source={source}
-          target={target}
-        />
-      );
+      values.push(<GraphEdge {...others} key={it.id} data={data} edge={it} source={source} target={target} />);
     }
   }
 
@@ -68,24 +60,15 @@ const EdgeChampNodeRender = React.memo<IEdgeChampNodeRenderProps>(props => {
 EdgeChampNodeRender.displayName = "EdgeChampNodeRender";
 
 const EdgeHashCollisionNodeRender = React.memo<IEdgeHashCollisionNodeRenderProps>(props => {
-  const { data, node, graphConfig, ...others } = props;
+  const { data, node, ...others } = props;
+  const graphConfig = useGraphConfig();
   return (
     <>
       {node.values.map(edge => {
         const source = data.nodes.get(edge.source)?.getPortPosition(edge.sourcePortId, graphConfig);
         const target = data.nodes.get(edge.target)?.getPortPosition(edge.targetPortId, graphConfig);
         if (source && target) {
-          return (
-            <GraphEdge
-              {...others}
-              key={edge.id}
-              data={data}
-              graphConfig={graphConfig}
-              edge={edge}
-              source={source}
-              target={target}
-            />
-          );
+          return <GraphEdge {...others} key={edge.id} data={data} edge={edge} source={source} target={target} />;
         } else {
           return null;
         }

--- a/packages/ReactDagEditor/src/contexts/AlignmentLinesContext.tsx
+++ b/packages/ReactDagEditor/src/contexts/AlignmentLinesContext.tsx
@@ -1,4 +1,4 @@
 import { createContext } from "react";
 import { ILine } from "../components/Line";
 
-export const AlignmentLinesContext = createContext<ILine[]>([]);
+export const AlignmentLinesContext = createContext<readonly ILine[]>([]);

--- a/packages/ReactDagEditor/src/hooks/context.ts
+++ b/packages/ReactDagEditor/src/hooks/context.ts
@@ -1,0 +1,34 @@
+import { useContext } from "react";
+import type { ILine } from "../components/Line";
+import { ViewportContext } from "../contexts";
+import { AlignmentLinesContext } from "../contexts/AlignmentLinesContext";
+import { ConnectingStateContext, IConnectingStateContext } from "../contexts/ConnectingStateContext";
+import { GraphConfigContext, IGraphConfig } from "../contexts/GraphConfigContext";
+import { GraphControllerContext } from "../contexts/GraphControllerContext";
+import { IVirtualizationContext, VirtualizationContext } from "../contexts/VirtualizationContext";
+import type { GraphController } from "../controllers/GraphController";
+import { IViewport } from "../models/geometry";
+
+export function useGraphConfig(): IGraphConfig {
+  return useContext(GraphConfigContext);
+}
+
+export function useGraphController(): GraphController {
+  return useContext(GraphControllerContext);
+}
+
+export function useViewport(): IViewport {
+  return useContext(ViewportContext);
+}
+
+export function useAlignmentLines(): readonly ILine[] {
+  return useContext(AlignmentLinesContext);
+}
+
+export function useConnectingState(): IConnectingStateContext {
+  return useContext(ConnectingStateContext);
+}
+
+export function useVirtualization(): IVirtualizationContext {
+  return useContext(VirtualizationContext);
+}

--- a/packages/ReactDagEditor/src/utils/autoAlign.ts
+++ b/packages/ReactDagEditor/src/utils/autoAlign.ts
@@ -31,13 +31,7 @@ export const getAlignmentLines = (
 ): ILine[] => {
   const dummyDraggingNodeHW = getDummyDraggingNode(draggingNodes);
 
-  const closestNodes = getClosestNodes(
-    dummyDraggingNodeHW,
-    draggingNodes,
-    nodes,
-    graphConfig,
-    threshold
-  );
+  const closestNodes = getClosestNodes(dummyDraggingNodeHW, draggingNodes, nodes, graphConfig, threshold);
 
   return getLines(dummyDraggingNodeHW, closestNodes, draggingNodes.length);
 };
@@ -49,7 +43,7 @@ export const getAlignmentLines = (
  * @param graphConfig graphConfig of type IGraphConfig
  */
 export const getAutoAlignDisplacement = (
-  alignmentLines: ILine[],
+  alignmentLines: readonly ILine[],
   nodes: readonly IDummyNode[],
   graphConfig: IGraphConfig,
   alignDirection: "x" | "y"
@@ -59,8 +53,7 @@ export const getAutoAlignDisplacement = (
 
   const nodeHW = getDummyDraggingNode(nodes);
 
-  const widthOrHeight =
-    alignDirection === "x" ? nodeHW.width || 0 : nodeHW.height || 0;
+  const widthOrHeight = alignDirection === "x" ? nodeHW.width || 0 : nodeHW.height || 0;
 
   alignmentLines.forEach(item => {
     let alignLine: number;
@@ -73,8 +66,7 @@ export const getAutoAlignDisplacement = (
     }
 
     const distance1 = nodeHW[alignDirection] - alignLine;
-    const distanceMiddle =
-      nodeHW[alignDirection] + (widthOrHeight || 0) / 2 - alignLine;
+    const distanceMiddle = nodeHW[alignDirection] + (widthOrHeight || 0) / 2 - alignLine;
     const distance2 = nodeHW[alignDirection] + (widthOrHeight || 0) - alignLine;
 
     if (Math.abs(distance1) < min) {
@@ -99,10 +91,7 @@ export const getAutoAlignDisplacement = (
  * @param nodes among these nodes to get the min coordinate
  * @param field "x"|"y"
  */
-const getMinCoordinate = (
-  nodes: ICanvasNode[],
-  field: "x" | "y"
-): number | undefined => {
+const getMinCoordinate = (nodes: ICanvasNode[], field: "x" | "y"): number | undefined => {
   if (!nodes.length) {
     return undefined;
   }
@@ -114,16 +103,11 @@ const getMinCoordinate = (
  * @param nodes among these nodes to get the max coordinate
  * @param field "x"|"y"
  */
-const getMaxCoordinate = (
-  nodes: ICanvasNode[],
-  field: "x" | "y"
-): number | undefined => {
+const getMaxCoordinate = (nodes: ICanvasNode[], field: "x" | "y"): number | undefined => {
   if (!nodes.length) {
     return undefined;
   }
-  return Math.max(
-    ...nodes.map(n => n[field] + (field === "y" ? n.height || 0 : n.width || 0))
-  );
+  return Math.max(...nodes.map(n => n[field] + (field === "y" ? n.height || 0 : n.width || 0)));
 };
 
 /**
@@ -131,10 +115,7 @@ const getMaxCoordinate = (
  * @param node the node to set height and width
  * @param graphConfig graphConfig of type IGraphConfig
  */
-const setSizeForNode = (
-  node: ICanvasNode,
-  graphConfig: IGraphConfig
-): ICanvasNode => {
+const setSizeForNode = (node: ICanvasNode, graphConfig: IGraphConfig): ICanvasNode => {
   return {
     ...node,
     ...getNodeSize(node, graphConfig)
@@ -190,9 +171,7 @@ const getBoundingBoxOfNodes = (
  * @param draggingNodes all dragging nodes
  * @param graphConfig graphConfig of type IGraphConfig
  */
-const getDummyDraggingNode = (
-  draggingNodes: readonly IDummyNode[]
-) => {
+const getDummyDraggingNode = (draggingNodes: readonly IDummyNode[]) => {
   const { x, y, width, height } = getBoundingBoxOfNodes(draggingNodes);
   const dummyDraggingNode: IDummyNode = {
     id: uuid(),
@@ -244,20 +223,16 @@ const getClosestNodes = (
     const { width: nodeWidth = 0, height: nodeHeight = 0 } = nodeHW;
 
     // compare X coordinate of dragging node
-    [
-      draggingNodeX,
-      draggingNodeX + draggingNodeWidth / 2,
-      draggingNodeX + draggingNodeWidth
-    ].forEach((draggingNodeValue, alignPos) => {
-      if (!resX[alignPos]) {
-        resX[alignPos] = {};
-      }
-      if (!resX[alignPos].closestNodes) {
-        resX[alignPos].closestNodes = [];
-      }
+    [draggingNodeX, draggingNodeX + draggingNodeWidth / 2, draggingNodeX + draggingNodeWidth].forEach(
+      (draggingNodeValue, alignPos) => {
+        if (!resX[alignPos]) {
+          resX[alignPos] = {};
+        }
+        if (!resX[alignPos].closestNodes) {
+          resX[alignPos].closestNodes = [];
+        }
 
-      [nodeHW.x, nodeHW.x + nodeWidth / 2, nodeHW.x + nodeWidth].forEach(
-        comparedValue => {
+        [nodeHW.x, nodeHW.x + nodeWidth / 2, nodeHW.x + nodeWidth].forEach(comparedValue => {
           const distance = Math.abs(draggingNodeValue - comparedValue);
           if (distance <= minDistanceX) {
             resX[alignPos].closestNodes?.push(nodeHW);
@@ -265,25 +240,21 @@ const getClosestNodes = (
 
             minDistanceX = distance;
           }
-        }
-      );
-    });
+        });
+      }
+    );
 
     // compare Y coordinate of dragging node
-    [
-      draggingNodeY,
-      draggingNodeY + draggingNodeHeight / 2,
-      draggingNodeY + draggingNodeHeight
-    ].forEach((draggingNodeValue, alignPos) => {
-      if (!resY[alignPos]) {
-        resY[alignPos] = {};
-      }
-      if (!resY[alignPos].closestNodes) {
-        resY[alignPos].closestNodes = [];
-      }
+    [draggingNodeY, draggingNodeY + draggingNodeHeight / 2, draggingNodeY + draggingNodeHeight].forEach(
+      (draggingNodeValue, alignPos) => {
+        if (!resY[alignPos]) {
+          resY[alignPos] = {};
+        }
+        if (!resY[alignPos].closestNodes) {
+          resY[alignPos].closestNodes = [];
+        }
 
-      [nodeHW.y, nodeHW.y + nodeHeight / 2, nodeHW.y + nodeHeight].forEach(
-        comparedValue => {
+        [nodeHW.y, nodeHW.y + nodeHeight / 2, nodeHW.y + nodeHeight].forEach(comparedValue => {
           const distance = Math.abs(draggingNodeValue - comparedValue);
           if (distance <= minDistanceY) {
             resY[alignPos].closestNodes?.push(nodeHW);
@@ -291,9 +262,9 @@ const getClosestNodes = (
 
             minDistanceY = distance;
           }
-        }
-      );
-    });
+        });
+      }
+    );
   });
   return { closestX: resX, closestY: resY };
 };
@@ -329,11 +300,7 @@ const getLines = (
     const sameXNodes: ICanvasNode[] = [];
     const x = item.alignCoordinateValue;
     item.closestNodes?.forEach(node => {
-      if (
-        node.x === x ||
-        node.x + (node.width || 0) / 2 === x ||
-        node.x + (node.width || 0) === x
-      ) {
+      if (node.x === x || node.x + (node.width || 0) / 2 === x || node.x + (node.width || 0) === x) {
         sameXNodes.push(node);
       }
     });
@@ -357,11 +324,7 @@ const getLines = (
     const y = item.alignCoordinateValue;
 
     item.closestNodes?.forEach(node => {
-      if (
-        node.y === y ||
-        node.y + (node.height || 0) / 2 === y ||
-        node.y + (node.height || 0) === y
-      ) {
+      if (node.y === y || node.y + (node.height || 0) / 2 === y || node.y + (node.height || 0) === y) {
         sameYNodes.push(node);
       }
     });

--- a/packages/ReactDagEditor/test/TestComponent.tsx
+++ b/packages/ReactDagEditor/test/TestComponent.tsx
@@ -10,8 +10,8 @@ import {
 } from "../src";
 import { Graph, GraphStateStore, IGraphProps, ReactDagEditor } from "../src/components";
 import { GraphConfigContext } from "../src/contexts";
-import { GraphControllerContext } from "../src/contexts/GraphControllerContext";
 import { GraphController } from "../src/controllers/GraphController";
+import { useGraphController } from "../src/hooks/context";
 import Sample0 from "../test/unit/__data__/sample0.json";
 
 const data: ICanvasData = {
@@ -41,7 +41,7 @@ afterEach(() => {
 });
 
 export const GraphControllerRef = React.forwardRef<GraphController>((_, ref) => {
-  const graphController = React.useContext(GraphControllerContext);
+  const graphController = useGraphController();
   React.useImperativeHandle(ref, () => graphController, [graphController]);
   return null;
 });


### PR DESCRIPTION
Access context values with these hooks so that we can optimize easily when do some refactor.
For example, reducing number of contexts and replace a monolithic context with context selectors, re-organize context structures 