### PR TITLE
Support stack order on canvas by node layer concept

### DIFF
--- a/packages/react-dag-editor/package.json
+++ b/packages/react-dag-editor/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "https://github.com/microsoft/react-dag-editor.git"
   },
-  "version": "0.2.5",
+  "version": "0.2.6",
   "dependencies": {
     "react-jss": "~10.2.0",
     "toposort": "^1.0.7",

--- a/packages/react-dag-editor/src/lib/components/Graph/Graph.tsx
+++ b/packages/react-dag-editor/src/lib/components/Graph/Graph.tsx
@@ -41,6 +41,9 @@ import { Scrollbar } from "../Scrollbar";
 import { Transform } from "../Transform";
 import { EdgeTree } from "../tree/EdgeTree";
 import { NodeTree } from "../tree/NodeTree";
+import { NodeLayers } from "../NodeLayers";
+import { OrderedMap } from "../../collections";
+import { NodeModel } from "../../models/NodeModel";
 import { VirtualizationProvider } from "../VirtualizationProvider";
 import { getGraphStyles } from "./Graph.styles";
 import type { IGraphProps } from "./IGraphProps";
@@ -197,6 +200,30 @@ export function Graph<
   const accessKey = isA11yEnable ? focusCanvasAccessKey : undefined;
   const touchHandlers = useGraphTouchHandler(rectRef, eventChannel);
 
+  const renderNodeTree = React.useCallback(
+    (tree: OrderedMap<string, NodeModel>) => (
+      <NodeTree
+        graphId={graphId}
+        isNodeResizable={isNodeResizable}
+        tree={tree}
+        data={data}
+        isNodeEditDisabled={isNodeEditDisabled}
+        eventChannel={eventChannel}
+        getNodeAriaLabel={props.getNodeAriaLabel ?? defaultGetNodeAriaLabel}
+        getPortAriaLabel={props.getPortAriaLabel ?? defaultGetPortAriaLabel}
+      />
+    ),
+    [
+      data,
+      eventChannel,
+      graphId,
+      isNodeEditDisabled,
+      isNodeResizable,
+      props.getNodeAriaLabel,
+      props.getPortAriaLabel,
+    ]
+  );
+
   if (!isSupported()) {
     const {
       onBrowserNotSupported = () => <p>Your browser is not supported</p>,
@@ -304,20 +331,7 @@ export function Graph<
                 data={data}
                 eventChannel={eventChannel}
               />
-              <NodeTree
-                graphId={graphId}
-                isNodeResizable={isNodeResizable}
-                tree={data.nodes}
-                data={data}
-                isNodeEditDisabled={isNodeEditDisabled}
-                eventChannel={eventChannel}
-                getNodeAriaLabel={
-                  props.getNodeAriaLabel ?? defaultGetNodeAriaLabel
-                }
-                getPortAriaLabel={
-                  props.getPortAriaLabel ?? defaultGetPortAriaLabel
-                }
-              />
+              <NodeLayers data={data} renderTree={renderNodeTree} />
             </VirtualizationProvider>
           )}
           {state.dummyNodes.isVisible && (

--- a/packages/react-dag-editor/src/lib/components/NodeLayers.tsx
+++ b/packages/react-dag-editor/src/lib/components/NodeLayers.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { GraphModel } from "../models/GraphModel";
+import { OrderedMap } from "../collections";
+import { NodeModel } from "../models/NodeModel";
+interface INodeLayersProps {
+  data: GraphModel;
+  renderTree(tree: OrderedMap<string, NodeModel>): JSX.Element;
+}
+export const NodeLayers: React.FC<INodeLayersProps> = ({
+  data,
+  renderTree,
+}) => {
+  const layers = new Set<number>();
+  data.nodes.forEach((n) => layers.add(n.layer));
+
+  return (
+    <>
+      {Array.from(layers.values())
+        .sort()
+        .map((l) => renderTree(data.nodes.filter((n) => n.layer === l)))}
+    </>
+  );
+};

--- a/packages/react-dag-editor/src/lib/models/NodeModel.ts
+++ b/packages/react-dag-editor/src/lib/models/NodeModel.ts
@@ -72,6 +72,10 @@ export class NodeModel<NodeData = unknown, PortData = unknown>
     return this.inner.width;
   }
 
+  public get layer(): number {
+    return this.inner.layer ?? 0;
+  }
+
   private constructor(
     node: ICanvasNode<NodeData, PortData>,
     portPositionCache: Map<string, IPoint | undefined>,

--- a/packages/react-dag-editor/src/lib/models/node.ts
+++ b/packages/react-dag-editor/src/lib/models/node.ts
@@ -16,4 +16,5 @@ export interface ICanvasNode<T = unknown, P = unknown> {
   readonly ports?: ReadonlyArray<ICanvasPort<P>>;
   readonly ariaLabel?: string;
   readonly data?: Readonly<T>;
+  readonly layer?: number;
 }

--- a/packages/react-dag-editor/src/stories/components/FeaturesDemo.tsx
+++ b/packages/react-dag-editor/src/stories/components/FeaturesDemo.tsx
@@ -82,7 +82,7 @@ const sourceNodeConfig: INodeConfig = {
 
 const stepNodeConfig: INodeConfig = {
   getMinHeight: () => 64,
-  getMinWidth: (model) => 120 + (model.name?.length ?? 0) * 12,
+  getMinWidth: (model) => model.width ?? 120 + (model.name?.length ?? 0) * 12,
   render: (args) => {
     const height = getRectHeight(stepNodeConfig, args.model);
     const width = getRectWidth(stepNodeConfig, args.model);

--- a/packages/react-dag-editor/src/stories/data/sample-graph-1.ts
+++ b/packages/react-dag-editor/src/stories/data/sample-graph-1.ts
@@ -3,7 +3,7 @@ import { ICanvasData } from "../..";
 export const sampleGraphData: ICanvasData = {
   nodes: [
     {
-      id: "source",
+      id: "source-1",
       name: "source",
       ports: [
         {
@@ -94,6 +94,24 @@ export const sampleGraphData: ICanvasData = {
       x: 600,
       y: 400,
       shape: "step",
+    },
+    {
+      id: "step-3",
+      name: "Step at upper layer will cover others",
+      x: 300,
+      y: 200,
+      width: 450,
+      layer: 10,
+      shape: "step",
+    },
+    {
+      id: "source-2",
+      name: "source 2",
+      ports: [],
+      data: {},
+      x: 620,
+      y: 180,
+      shape: "source",
     },
   ],
   edges: [],


### PR DESCRIPTION
Like `z-index` property in CSS, the newly implemented `layer` property in node model specifies the stack order of an element on the canvas. Assuming there is an overlap between two elements on the canvas, the rule is the latter rendered element will cover the former rendered one. Thus we use `layer` property to order the rendering sequence of nodes by group, and the nodes with same layer number still follow the rule.

There is also an update for the storybook to demo this ability.

![image](https://user-images.githubusercontent.com/8896124/210967427-1eebc655-0796-445b-b931-9ada119264c9.png)
